### PR TITLE
add html generation in recruitment.js

### DIFF
--- a/js/contactInfo.js
+++ b/js/contactInfo.js
@@ -1,3 +1,3 @@
 export let contactInfoRequest =
-  fetch('https://laafte.samfundet.no/api/kontaktinfo/')
+  fetch('../api/kontaktinfo/')
     .then(response => response.json());

--- a/js/contactInfo.js
+++ b/js/contactInfo.js
@@ -1,3 +1,3 @@
 export let contactInfoRequest =
-  fetch('../api/kontaktinfo/')
+  fetch('/api/kontaktinfo/')
     .then(response => response.json());

--- a/js/contactInfo.js
+++ b/js/contactInfo.js
@@ -1,1 +1,3 @@
-export let contactInfoRequest = fetch('https://laafte.samfundet.no/api/kontaktinfo/').then(response => response.json());
+export let contactInfoRequest =
+  fetch('https://laafte.samfundet.no/api/kontaktinfo/')
+    .then(response => response.json());

--- a/js/recruitment.js
+++ b/js/recruitment.js
@@ -9,22 +9,22 @@ import { recruitmentInfoRequest } from './recruitmentInfo.js';
 let contactInfo = null;
 let recruitmentInfo = null;
 
-const contactLoaded = (data) => {
+function contactLoaded(data) {
   contactInfo = data;
-  if(recruitmentInfo != null) {
+  if (recruitmentInfo != null) {
     createHTML(contactInfo, recruitmentInfo);
   }
 }
 
-const recruitmentLoaded = (data) => {
+function recruitmentLoaded(data) {
   recruitmentInfo = data;
-  if(contactInfo != null) {
+  if (contactInfo != null) {
     createHTML(contactInfo, recruitmentInfo);
   }
 }
 
 // Listen for both fetches
-document.addEventListener('DOMContentLoaded', event => {
+document.addEventListener('DOMContentLoaded', (event) => {
   contactInfoRequest.then(contactLoaded);
   recruitmentInfoRequest.then(recruitmentLoaded);
 });
@@ -56,7 +56,7 @@ function createWrapperTemplate() {
 }
 
 // only run when all data is ready
-const createHTML = (contactInfo, recruitmentInfo) => {
+function createHTML(contactInfo, recruitmentInfo) {
   let container = document.getElementById('band-recruitment-container');
 
   const nameMap = {
@@ -72,7 +72,7 @@ const createHTML = (contactInfo, recruitmentInfo) => {
 
   let baseWrapperNode = createWrapperTemplate(); 
   
-  for(let i = 0; i < recruitmentInfo.length; i++) {
+  for (let i = 0; i < recruitmentInfo.length; i++) {
     // Make sure this group is active before rendering
     let isActive = recruitmentInfo[i].aktiv;
     if(!isActive) {
@@ -98,8 +98,8 @@ const createHTML = (contactInfo, recruitmentInfo) => {
     
     // Setup contents
     // No recruitment text is interpreted as no free positions
-    if(recrText === null || recrText === '') {
-      recrText = 'Ingen opptak dette semesteret.'
+    if (recrText === null || recrText === '') {
+      recrText = 'Intet opptak dette semesteret.';
       recrTextNode.style.fontStyle = 'italic';
       recruiting = false;
     }
@@ -115,7 +115,7 @@ const createHTML = (contactInfo, recruitmentInfo) => {
 
     // Contact information
     // Only add if actually recruiting
-    if(recruiting) {
+    if (recruiting) {
       contactLink.href='mailto:' + contactAddr + '?subject=Opptak';
       contactLink.textContent = contactAddr;
       

--- a/js/recruitment.js
+++ b/js/recruitment.js
@@ -1,5 +1,136 @@
 import { contactInfoRequest } from "./contactInfo.js";
+import { recruitmentInfoRequest } from "./recruitmentInfo.js";
 
+/*
+ * Trying to augment this version to both support API fetch of
+ * contact info and recruitment text
+ */
+
+let contactInfo = null;
+let recruitmentInfo = null;
+
+const contactLoaded = (data) => {
+  contactInfo = data;
+  if(recruitmentInfo != null) {
+    createHTML(contactInfo, recruitmentInfo);
+  }
+}
+
+const recruitmentLoaded = (data) => {
+  recruitmentInfo = data;
+  if(contactInfo != null) {
+    createHTML(contactInfo, recruitmentInfo);
+  }
+}
+
+// Listen for both fetches
+document.addEventListener("DOMContentLoaded", event => {
+  contactInfoRequest.then(contactLoaded);
+  recruitmentInfoRequest.then(recruitmentLoaded);
+});
+
+
+// We create a reusable template for the content
+// This approach makes it easier to avoid .innerHMTL to the benefit of .textContent,
+// reducing the need for trusting/sanitising our input. It's also faster (presumably)!
+// Main drawback is somewhat tedious manual DOM tree building.
+function createWrapperTemplate() {
+  let baseWrapperNode = document.createElement('div');
+  baseWrapperNode.className = "band";
+
+  let wrapperHeadingTop = document.createElement('h3');
+  baseWrapperNode.appendChild(wrapperHeadingTop);
+
+  let wrapperHeadingSub = document.createElement('h4');
+  wrapperHeadingSub.textContent = 'Ledige plasser:';
+  baseWrapperNode.appendChild(wrapperHeadingSub);
+
+  let longTextElem = document.createElement('p');
+  longTextElem.className='longer-text';
+  
+  for(let i = 0; i < 3; i++) {
+    baseWrapperNode.appendChild(longTextElem.cloneNode());
+  }
+  
+  return baseWrapperNode;
+}
+
+// only run when all data is ready
+const createHTML = (contactInfo, recruitmentInfo) => {
+  let container = document.getElementById("band-recruitment-container");
+  console.log(contactInfo, recruitmentInfo);
+
+  const nameMap = {
+    'lsl': 'Leisure Suit Lovers',
+    'kb': 'Kjellerbandet',
+    'salongen': 'Studentersamfundets Salongorkester',
+    'revy': 'Revybandet',
+    'smoller': 'S. Møller Storband',
+    'sfo': 'Samfundets Fusion Orkester',
+    'symforch': 'Studentersamfundets Symfoniorkester'
+  };
+
+
+  let baseWrapperNode = createWrapperTemplate(); 
+  
+  for(let i = 0; i < recruitmentInfo.length; i++) {
+    // Make sure this group is active before rendering
+    let isActive = recruitmentInfo[i].aktiv;
+    if(!isActive)
+      continue;
+
+    // Setup all the DOM references we need
+    // Trying to be 100% consistent with old impl, thus no new classes for identification
+    let wrapperNode = baseWrapperNode.cloneNode(true); // deep copy of base template
+    let topHeaderNode = wrapperNode.querySelector('h3');
+    let longTextNodes = wrapperNode.querySelectorAll('p');
+    let recrTextNode = longTextNodes[0];
+    let contactTextNode = longTextNodes[2];
+    let contactLink = document.createElement('a');
+    contactLink.style.whiteSpace = 'nowrap';
+    
+    let recrText = recruitmentInfo[i].rekruteringstekst;
+    let contactAddr = recruitmentInfo[i].kontaktinfo;
+
+    let groupName = nameMap[recruitmentInfo[i].gruppering];
+
+    let recruiting = true;
+    
+    // Setup contents
+    // No recruitment text is interpreted as no free positions
+    if(recrText === null || recrText === "") {
+      recrText = "Ingen opptak dette semesteret."
+      recrTextNode.style.fontStyle = 'italic';
+      recruiting = false;
+    }
+
+    // Header
+    topHeaderNode.textContent = groupName;
+
+    // Recruitment text body
+    // Making an exception to not break Snaus link.
+    // ASK IF WE ACTUALLY MUST SUPPORT THIS
+    recrTextNode.innerHTML = recrText;
+
+
+    // Contact information
+    // Only add if actually recruiting
+    if(recruiting) {
+      contactLink.href="mailto:" + contactAddr + "?subject=Opptak";
+      contactLink.textContent = contactAddr;
+      
+      // Must be sandwitched between text nodes
+      contactTextNode.append(document.createTextNode("Send epost til "));
+      contactTextNode.append(contactLink);
+      contactTextNode.append(document.createTextNode(" for å melde interesse."));
+    }
+    // Add finished DOM tree to main container
+    container.append(wrapperNode);
+  }
+}
+
+
+/*
 function onRecruitmentLoaded(data) {
   let container = document.getElementById("band-recruitment-container");
 
@@ -83,3 +214,4 @@ function onRecruitmentLoaded(data) {
 document.addEventListener("DOMContentLoaded", event => {
   contactInfoRequest.then(onRecruitmentLoaded);
 });
+*/

--- a/js/recruitment.js
+++ b/js/recruitment.js
@@ -1,5 +1,5 @@
-import { contactInfoRequest } from "./contactInfo.js";
-import { recruitmentInfoRequest } from "./recruitmentInfo.js";
+import { contactInfoRequest } from './contactInfo.js';
+import { recruitmentInfoRequest } from './recruitmentInfo.js';
 
 /*
  * Trying to augment this version to both support API fetch of
@@ -24,7 +24,7 @@ const recruitmentLoaded = (data) => {
 }
 
 // Listen for both fetches
-document.addEventListener("DOMContentLoaded", event => {
+document.addEventListener('DOMContentLoaded', event => {
   contactInfoRequest.then(contactLoaded);
   recruitmentInfoRequest.then(recruitmentLoaded);
 });
@@ -36,7 +36,7 @@ document.addEventListener("DOMContentLoaded", event => {
 // Main drawback is somewhat tedious manual DOM tree building.
 function createWrapperTemplate() {
   let baseWrapperNode = document.createElement('div');
-  baseWrapperNode.className = "band";
+  baseWrapperNode.className = 'band';
 
   let wrapperHeadingTop = document.createElement('h3');
   baseWrapperNode.appendChild(wrapperHeadingTop);
@@ -46,9 +46,9 @@ function createWrapperTemplate() {
   baseWrapperNode.appendChild(wrapperHeadingSub);
 
   let longTextElem = document.createElement('p');
-  longTextElem.className='longer-text';
+  longTextElem.className = 'longer-text';
   
-  for(let i = 0; i < 3; i++) {
+  for (let i = 0; i < 3; i++) {
     baseWrapperNode.appendChild(longTextElem.cloneNode());
   }
   
@@ -57,8 +57,7 @@ function createWrapperTemplate() {
 
 // only run when all data is ready
 const createHTML = (contactInfo, recruitmentInfo) => {
-  let container = document.getElementById("band-recruitment-container");
-  console.log(contactInfo, recruitmentInfo);
+  let container = document.getElementById('band-recruitment-container');
 
   const nameMap = {
     'lsl': 'Leisure Suit Lovers',
@@ -76,8 +75,9 @@ const createHTML = (contactInfo, recruitmentInfo) => {
   for(let i = 0; i < recruitmentInfo.length; i++) {
     // Make sure this group is active before rendering
     let isActive = recruitmentInfo[i].aktiv;
-    if(!isActive)
+    if(!isActive) {
       continue;
+    }
 
     // Setup all the DOM references we need
     // Trying to be 100% consistent with old impl, thus no new classes for identification
@@ -98,8 +98,8 @@ const createHTML = (contactInfo, recruitmentInfo) => {
     
     // Setup contents
     // No recruitment text is interpreted as no free positions
-    if(recrText === null || recrText === "") {
-      recrText = "Ingen opptak dette semesteret."
+    if(recrText === null || recrText === '') {
+      recrText = 'Ingen opptak dette semesteret.'
       recrTextNode.style.fontStyle = 'italic';
       recruiting = false;
     }
@@ -108,110 +108,24 @@ const createHTML = (contactInfo, recruitmentInfo) => {
     topHeaderNode.textContent = groupName;
 
     // Recruitment text body
-    // Making an exception to not break Snaus link.
-    // ASK IF WE ACTUALLY MUST SUPPORT THIS
+    // Using innerHTML to no break Snaus link.
+    // Not a neccessity and maybe unsafe, but we'll keep it for now
     recrTextNode.innerHTML = recrText;
 
 
     // Contact information
     // Only add if actually recruiting
     if(recruiting) {
-      contactLink.href="mailto:" + contactAddr + "?subject=Opptak";
+      contactLink.href='mailto:' + contactAddr + '?subject=Opptak';
       contactLink.textContent = contactAddr;
       
       // Must be sandwitched between text nodes
-      contactTextNode.append(document.createTextNode("Send epost til "));
+      contactTextNode.append(document.createTextNode('Send epost til '));
       contactTextNode.append(contactLink);
-      contactTextNode.append(document.createTextNode(" for å melde interesse."));
+      contactTextNode.append(document.createTextNode(' for å melde interesse.'));
     }
     // Add finished DOM tree to main container
     container.append(wrapperNode);
   }
 }
 
-
-/*
-function onRecruitmentLoaded(data) {
-  let container = document.getElementById("band-recruitment-container");
-
-  let leaderRoles = [
-    "kb-leder",
-    "lsl-leder",
-    "smoller-leder",
-    "snau-leder",
-    "salong-leder",
-    "symforch-formann",
-    "sfo-leder"
-  ];
-
-  let leaderInBand = {
-    "kb-leder": ["Kjellerbandet", "kb-sjef@samfundet.no"],
-    "lsl-leder": ["Leisure Suit Lovers", "lsl@samfundet.no"],
-    "smoller-leder": ["S. Møller Storband", "post@smoller.no"],
-    "snau-leder": [
-      "Snaustrinda Spelemannslag",
-      "snaustrinda-sjef@samfundet.no"
-    ],
-    "salong-leder": [
-      "Studentersamfundets Salongsorkester",
-      "salong@samfundet.no"
-    ],
-    "symforch-formann": [
-      "Studentersamfundets Symfoniorkester",
-      "symforch-leder@samfundet.no"
-    ],
-    "sfo-leder": [
-      "Samfundets Fusion Orkester", 
-      "laafte-sfo@samfundet.no"]
-  };
-
-  let availableSeatsInBand = {
-    "Kjellerbandet": 
-      "KB har opptak på piano! Ta kontakt hvis du er interessert.",
-    "Leisure Suit Lovers": "Er du interessert i Disco? Liker du ABBA, Earth, Wind & Fire og andre 70/80-talls hits? Søk Leisure Suit Lovers! LSL søker en discoglad musiker på trompet til V22! Søk søk søk!",
-    "S. Møller Storband": null, 
-    "Snaustrinda Spelemannslag": 
-      "Vi søkjer nye musikarar på gitar, kontrabass, blås og trekkspel, men alle som er interessert i folkemusikk og speler eit instrument er velkomen på open øving! Sjå <a href=\"https://facebook.com/Snaustrinda/\">Facebook-sida vår</a> for meir info.",
-    "Studentersamfundets Salongsorkester": null,
-    "Studentersamfundets Symfoniorkester": 
-      "Symforch har opptak på obo og fiolin! Send en e-post hvis du er interessert. 🎻🎻🎻",
-    "Samfundets Fusion Orkester": null 
-  };
-
-  let leaders = data.contacts.filter(contact =>
-    leaderRoles.includes(contact.role)
-  );
-
-  leaders.sort(
-    (a, b) => leaderRoles.indexOf(a.role) - leaderRoles.indexOf(b.role)
-  );
-
-  leaders.forEach(leader => {
-    let container = document.getElementById("band-recruitment-container");
-    let node = document.createElement("div");
-    let band = leaderInBand[leader.role][0];
-    let availableSeats = availableSeatsInBand[band];
-    node.className = "band";
-    node.innerHTML = `<h3>${band}</h3>
-        <h4>Ledige plasser:</h4>
-        ${
-      availableSeats == null
-        ? "<p class='longer-text'><span style='font-style: italic'>Ingen opptak dette semesteret. </span></p>"
-        : `<p class='longer-text'>${availableSeats}</p><p class='longer-text'><p class="longer-text"> Send epost til <a style = " white-space:nowrap; " href="mailto:${
-        leader.email == null
-          ? leaderInBand[leader.role][1]
-          : leader.email
-        }?subject=Opptak">${
-        leader.email == null
-          ? leaderInBand[leader.role][1]
-          : leader.email
-        }</a> for å melde interesse.</p> `
-      }`;
-    container.appendChild(node);
-  });
-}
-
-document.addEventListener("DOMContentLoaded", event => {
-  contactInfoRequest.then(onRecruitmentLoaded);
-});
-*/

--- a/js/recruitmentInfo.js
+++ b/js/recruitmentInfo.js
@@ -1,3 +1,3 @@
 export let recruitmentInfoRequest =
-  fetch('../api/rekruteringsinfo/')
+  fetch('/api/rekruteringsinfo/')
     .then(response => response.json());

--- a/js/recruitmentInfo.js
+++ b/js/recruitmentInfo.js
@@ -1,3 +1,3 @@
 export let recruitmentInfoRequest =
-  fetch('https://laafte.samfundet.no/api/rekruteringsinfo/')
+  fetch('../api/rekruteringsinfo/')
     .then(response => response.json());

--- a/js/recruitmentInfo.js
+++ b/js/recruitmentInfo.js
@@ -1,0 +1,3 @@
+export let recruitmentInfoRequest =
+  fetch('https://laafte.samfundet.no/api/rekruteringsinfo/')
+    .then(response => response.json());


### PR DESCRIPTION
based on api/rekruteringsinfo rather than api/kontaktinfo. This makes both contact address and text description editable from /edit_content. Super lightweight CMS!

Denne pull-requesten gjør at rekruteringstekst hentes fra https://laafte.samfundet.no/api/rekruteringsinfo/ heller enn fra et js-objekt i kildefila. API-endepunktet er dokumentert i https://laafte.samfundet.no/api-doc/#GET_/rekruteringsinfo.

API-et henter data fra låftes database på sql.samfundet.no. Data kan vises og redigeres vha https://laafte.samfundet.no/edit_content/edit_handlers/edit_recruitment.php, men redigering er låst til medlemmer av Låfte. Låftestyret har bedt om at det skal være begrensa til styret/"de som trenger", jeg tar kontakt med ITK for å få satt opp en ny itkacl-greie. 

Dette er funksjonalitet som låftestyret ønsker, og Jakob har fått prøvd det ut og gitt tommel opp. Synes derfor at denne pull-requesten kun skal stoppes hvis den inneholder tekniske problemer, så kan vi heller vurdere seinere om vi ønsker å generere statiske sider heller enn å gjøre alt dynamisk